### PR TITLE
Add DJ Mixes page with SoundCloud placeholders

### DIFF
--- a/anngie-master/css/style.css
+++ b/anngie-master/css/style.css
@@ -394,3 +394,21 @@ img {
 
   
 }
+
+/* DJ Mixes page */
+.mixes-container {
+    max-width: 800px;
+    margin: 50px auto;
+    padding: 0 20px;
+}
+
+.mix {
+    margin-bottom: 40px;
+}
+
+.mix iframe {
+    width: 100%;
+    height: 166px;
+    border: none;
+}
+

--- a/anngie-master/djmixes.html
+++ b/anngie-master/djmixes.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>DJ Mixes - Anngie Dehoyos</title>
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <link rel="stylesheet" href="css/style.css">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Poiret+One" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Homemade+Apple|Monoton" rel="stylesheet">
+</head>
+<body>
+  <nav>
+      <a href="" class="hamburger"><i class="fa fa-bars" aria-hidden="true"></i></a>
+      <div class="nav-links">
+    <ul>
+      <li><a class="space-right" href="index.html#image">About Me</a></li>
+      <li><a class="space-right" href="index.html#writing">Editorial Work</a></li>
+      <li><a class="space-right" href="photogallery.html">Photo Gallery</a></li>
+      <li><a class="space-right" href="djmixes.html">DJ Mixes</a></li>
+      <li><a class="space-right" href="index.html#hello">Say Hello</a></li>
+    </ul>
+  </div>
+  </nav>
+
+  <div class="mixes-container">
+    <h2>DJ Mixes</h2>
+
+    <div class="mix">
+      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123456789&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+    </div>
+
+    <div class="mix">
+      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/987654321&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+    </div>
+
+    <div class="mix">
+      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/192837465&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+    </div>
+  </div>
+
+  <script   src="https://code.jquery.com/jquery-3.1.1.js"   integrity="sha256-16cdPddA6VdVInumRGo6IbivbERE8p7CQR3HzTBuELA="   crossorigin="anonymous"></script>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/anngie-master/index.html
+++ b/anngie-master/index.html
@@ -19,6 +19,7 @@
       <li><a class="space-right" href="#image">About Me</a></li>
       <li><a class="space-right" href="#writing">Editorial Work</a></li>
       <li><a class="space-right" href="photogallery.html">Photo Gallery</a></li>
+      <li><a class="space-right" href="djmixes.html">DJ Mixes</a></li>
       <li><a class="space-right" href="#hello">Say Hello</a></li>
     </ul>
 </div>


### PR DESCRIPTION
## Summary
- Add navigation tab linking to new DJ Mixes page
- Create DJ Mixes page with placeholder SoundCloud embeds
- Style DJ Mixes section for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5707a28248322885118cada598375