### PR TITLE
Add responsive DJ mixes grid with placeholder text

### DIFF
--- a/anngie-master/css/style.css
+++ b/anngie-master/css/style.css
@@ -76,14 +76,16 @@ main{
 
 .mixes-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   grid-column-gap: 44px;
+  grid-row-gap: 44px;
   padding-top: 15px;
   max-width: 80%;
   margin: 0 auto;
 }
 
 .mixes-grid .overlay-wrapper {
+  width: 100%;
   height: 300px;
 }
 
@@ -292,6 +294,11 @@ Responsive
       grid-column-gap: 100px;
     }
 
+  .mixes-grid{
+      grid-template-columns: repeat(3, 1fr);
+      grid-column-gap: 100px;
+  }
+
 .about-section img {
   max-width: 100%;
   border-radius: 50%;
@@ -301,6 +308,11 @@ Responsive
 
 @media screen and (max-width:882px) {
   main{
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-gap: 100px;
+  }
+
+  .mixes-grid{
       grid-template-columns: repeat(2, 1fr);
       grid-column-gap: 100px;
   }
@@ -345,12 +357,20 @@ nav li {
         grid-template-columns: repeat(2, 1fr);
         grid-column-gap: 50px;
     }
+    .mixes-grid{
+        grid-template-columns: repeat(2, 1fr);
+        grid-column-gap: 50px;
     }
+}
 
 
 
 @media screen and (max-width:630px) {
   main{
+      grid-template-columns: repeat(1, 1fr);
+  }
+
+  .mixes-grid{
       grid-template-columns: repeat(1, 1fr);
   }
 
@@ -423,18 +443,13 @@ img {
 }
 
 .mix {
-    margin-bottom: 40px;
+    display: flex;
+    flex-direction: column;
 }
 
-.mix iframe {
-    width: 100%;
-    height: 166px;
-    border: none;
+.mix p {
+    margin-top: 8px;
 }
-.mix h3 {
-    font-size: 24px;
-    margin-bottom: 10px;
-} 
 
 
 

--- a/anngie-master/djmixes.html
+++ b/anngie-master/djmixes.html
@@ -27,17 +27,29 @@
 
   <div class="mixes-container">
     <h2>DJ Mixes</h2>
+    <div class="mixes-grid">
 
-    <div class="mix">
-      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123456789&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
-    </div>
+      <div class="mix">
+        <div class="overlay-wrapper">
+          <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123456789&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+        </div>
+        <p>Mix description coming soon.</p>
+      </div>
 
-    <div class="mix">
-      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/987654321&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
-    </div>
+      <div class="mix">
+        <div class="overlay-wrapper">
+          <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/987654321&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+        </div>
+        <p>Mix description coming soon.</p>
+      </div>
 
-    <div class="mix">
-      <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/192837465&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+      <div class="mix">
+        <div class="overlay-wrapper">
+          <iframe scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/192837465&color=%23ff5500&inverse=false&auto_play=false&show_user=true"></iframe>
+        </div>
+        <p>Mix description coming soon.</p>
+      </div>
+
     </div>
   </div>
 

--- a/anngie-master/index.html
+++ b/anngie-master/index.html
@@ -89,43 +89,68 @@
   <h2 class="editorial">Anngie's DJ Mixes</h2>
   <div class="mixes-grid">
 
-        <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1441502086&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1441502086&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
-
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1631159748&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1631159748&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
-
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2148086550&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2148086550&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1739019846&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1739019846&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1608524070&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1608524070&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
-
-
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2106575844&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-    </div>
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2046334600&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-    </div>
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1930806062&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-    </div>
-    <div class="overlay-wrapper">
-      <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1795389370&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2106575844&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
     </div>
 
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2046334600&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
+    </div>
+
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1930806062&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
+    </div>
+
+    <div class="mix">
+      <div class="overlay-wrapper">
+        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1795389370&color=%23544844&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+      </div>
+      <p>Mix description coming soon.</p>
+    </div>
 
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Rework DJ mixes section into a three-column grid with row spacing
- Add responsive media queries so mixes collapse cleanly on smaller screens
- Include placeholder descriptions beneath each mix on dedicated and home pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a655124f7c8322bdf795890ad41630