### PR TITLE
Add minimalist landing page with icon navigation

### DIFF
--- a/anngie-master/css/landing.css
+++ b/anngie-master/css/landing.css
@@ -1,0 +1,68 @@
+/* Landing page styles */
+body {
+  margin: 0;
+  background: #000;
+  color: #fff;
+  font-family: 'Montserrat', sans-serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 1rem 0;
+  background: transparent;
+}
+
+.main-nav ul {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.main-nav a {
+  color: #fff;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.85rem;
+  transition: color 0.2s ease;
+}
+
+.main-nav a:hover {
+  color: #ff69b4;
+}
+
+.main-nav i {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.intro {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.intro h1 {
+  font-size: 3rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.intro h2 {
+  font-size: 1.5rem;
+  margin-top: 0.5rem;
+  font-weight: 400;
+}

--- a/anngie-master/landing.html
+++ b/anngie-master/landing.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anngie Dehoyos</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/landing.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="#about"><i class="fa fa-user" aria-hidden="true"></i><span>About</span></a></li>
+      <li><a href="#projects"><i class="fa fa-folder-open" aria-hidden="true"></i><span>Projects</span></a></li>
+      <li><a href="#archive"><i class="fa fa-archive" aria-hidden="true"></i><span>Archive</span></a></li>
+      <li><a href="photogallery.html"><i class="fa fa-camera" aria-hidden="true"></i><span>Photography</span></a></li>
+      <li><a href="djmixes.html"><i class="fa fa-headphones" aria-hidden="true"></i><span>DJ Mixes</span></a></li>
+    </ul>
+  </nav>
+  <section class="intro">
+    <h1>Anngie Dehoyos</h1>
+    <h2>Content Creator</h2>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add new `landing.html` with black background and Font Awesome icon navigation linking to key sections.
- Style landing page through `css/landing.css` for centered name and tagline.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67bec9acc832291ff90546748bc84